### PR TITLE
bind `this` to ensure we don't loose context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 export default function addAssertions (tape, assertions) {
-    return (testName, testBody) => tape(testName, (t) => {
-        Object.assign(t, assertions);
-        testBody(t);
+    return (testName, testBody) => tape(testName, function (t) {
+        for(let prop in assertions) {
+            t[prop] = assertions[prop].bind(t);
+        }
+        testBody.call(this, t);
     });
 }


### PR DESCRIPTION
Fix `Cannot read property 'equals' of undefined`. Otherwise we can't use the destructuring to use `jsxEquals` : 

``` js
test('MyComponent is properly rendered', ( { jsxEquals } ) => {
    ...
    // compare output with the expected result:
    jsxEquals(result, <div className="box color-red"></div>); // throw Uncaught TypeError
    ...
});
```
