### PR TITLE
Added support of the full tapes list arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,20 @@
 export default function addAssertions (tape, assertions) {
-    return (testName, testBody) => tape(testName, t => {
-        for (let prop in assertions) {
-            t[prop] = assertions[prop].bind(t);
+    return function (name, opts, callback) {
+        const overrideCb = cb => t => {
+            for (let prop in assertions) {
+                t[prop] = assertions[prop].bind(t);
+            }
+
+            t.test = addAssertions(t.test, assertions);
+
+            cb.call(t, t);
+        };
+
+        switch (arguments.length) {
+            case 1: return tape(overrideCb(name));
+            case 2: return tape(name, overrideCb(opts));
+            case 3: return tape(name, opts, overrideCb(callback));
+            default: return tape.apply(this, arguments);
         }
-
-        t.test = addAssertions(t.test, assertions);
-
-        testBody.call(t, t);
-    });
+    };
 }


### PR DESCRIPTION
Add support when we call `test` method with 1 or 3 arguments : 

``` js
test((t) => { ... });
```

and

``` js
test('MyComponent is properly rendered', { timeout: 500 }, (t) => { ... });
```

I'll add those test cases during the week :)
